### PR TITLE
#34 - Fixes build scripts

### DIFF
--- a/buildScripts/build.bat
+++ b/buildScripts/build.bat
@@ -1,5 +1,18 @@
-set /p path=Enter Python3 folder exe path: 
-%path%\python.exe -m pip install pipenv 
-%path%\python.exe -m pipenv install --ignore-pipfile --python %path%
-%path%\python.exe -m pipenv run pyinstaller --onefile ../python/art.py
+::===============================================================
+:: To define the Python3 folder path remove comment (::) from 
+:: the following line and put the path to the folder.
+::===============================================================
+
+::set py_path=PATH/TO/PYTHONFOLDER 
+
+
+
+
+::============================
+:: DO NOT CHANGE BELOW THIS
+::============================
+if NOT DEFINED py_path set /p py_path=Python path not defined. Please enter Python3 folder exe path: 
+%py_path%\python.exe -m pip install pipenv 
+%py_path%\python.exe -m pipenv install --ignore-pipfile --python %py_path%\python.exe
+%py_path%\python.exe -m pipenv run pyinstaller --onefile ../python/art.py
 pause


### PR DESCRIPTION
Adds python executable call that was missing in the command and adds configuration option to set the path for python definetely.

Just need to edit the .bat file and uncomment the set py_path variable and put the path to folder.

@campuzanofj 